### PR TITLE
Safely retrieve refresh_token using .get() method

### DIFF
--- a/petsafe_smartfeed/client.py
+++ b/petsafe_smartfeed/client.py
@@ -179,7 +179,7 @@ class PetSafeClient:
 
         self.id_token = response["AuthenticationResult"]["IdToken"]
         self.access_token = response["AuthenticationResult"]["AccessToken"]
-        self.refresh_token = response["AuthenticationResult"]["RefreshToken"]
+        self.refresh_token = response["AuthenticationResult"].get("RefreshToken", self.refresh_token)
         self.token_expires_time = (
             time.time() + response["AuthenticationResult"]["ExpiresIn"]
         )


### PR DESCRIPTION
Use .get() to safely retrieve refresh_token. Resolves issue with immediate refreshes throwing immediate error: 

  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/petsafe_smartfeed/client.py", line 182, in refresh_tokens
    self.refresh_token = response["AuthenticationResult"]["RefreshToken"]